### PR TITLE
Fix bug in findLastFullyVisibleItemIndex()

### DIFF
--- a/TabSyncCompose/src/main/java/com/ahmadhamwi/tabsync_compose/LazyListStateKtx.kt
+++ b/TabSyncCompose/src/main/java/com/ahmadhamwi/tabsync_compose/LazyListStateKtx.kt
@@ -2,9 +2,9 @@ package com.ahmadhamwi.tabsync_compose
 
 import androidx.compose.foundation.lazy.LazyListState
 
-fun LazyListState.findFirstFullyVisibleItemIndex(): Int = findFullyVisibleItemIndex(reversed = true)
+fun LazyListState.findFirstFullyVisibleItemIndex(): Int = findFullyVisibleItemIndex(reversed = false)
 
-fun LazyListState.findLastFullyVisibleItemIndex(): Int = findFullyVisibleItemIndex(reversed = false)
+fun LazyListState.findLastFullyVisibleItemIndex(): Int = findFullyVisibleItemIndex(reversed = true)
 
 fun LazyListState.findFullyVisibleItemIndex(reversed: Boolean): Int {
     layoutInfo.visibleItemsInfo.run { if (reversed) reversed() else this }.forEach { itemInfo ->

--- a/TabSyncCompose/src/main/java/com/ahmadhamwi/tabsync_compose/LazyListStateKtx.kt
+++ b/TabSyncCompose/src/main/java/com/ahmadhamwi/tabsync_compose/LazyListStateKtx.kt
@@ -2,9 +2,9 @@ package com.ahmadhamwi.tabsync_compose
 
 import androidx.compose.foundation.lazy.LazyListState
 
-fun LazyListState.findFirstFullyVisibleItemIndex(): Int = findFullyVisibleItemIndex(true)
+fun LazyListState.findFirstFullyVisibleItemIndex(): Int = findFullyVisibleItemIndex(reversed = true)
 
-fun LazyListState.findLastFullyVisibleItemIndex(): Int = findFullyVisibleItemIndex(true)
+fun LazyListState.findLastFullyVisibleItemIndex(): Int = findFullyVisibleItemIndex(reversed = false)
 
 fun LazyListState.findFullyVisibleItemIndex(reversed: Boolean): Int {
     layoutInfo.visibleItemsInfo.run { if (reversed) reversed() else this }.forEach { itemInfo ->


### PR DESCRIPTION
Looks like there's a bug in `findLastFullyVisibleItemIndex()` (reverse == false, so it doesn't search for the last visible index). 

Feel free to just close this PR if I've misunderstood the implementation 🙂 